### PR TITLE
Add half-page scroll shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Vim-For-Docs is a browser extension that brings Vim-like navigation and editing 
 | `ge`             | Jump backward to end of previous word           |
 | `Ctrl + b`       | Page up                                         |
 | `Ctrl + f`       | Page down                                       |
+| `Ctrl + d`       | Move cursor and screen down 1/2 page            |
+| `Ctrl + u`       | Move cursor and screen up 1/2 page              |
 | `←`              | Move cursor left (or move word backward with Ctrl)|
 | `→`              | Move cursor right (or move word forward with Ctrl)|
 | `↑`              | Move cursor up (or jump to previous paragraph with Ctrl)|

--- a/src/content.js
+++ b/src/content.js
@@ -591,8 +591,20 @@
     sendKeyEvent("up", { control: true, shift }); 
   }
   
-  function goToNextPara(shift = false) { 
-    sendKeyEvent("down", { control: true, shift }); 
+  function goToNextPara(shift = false) {
+    sendKeyEvent("down", { control: true, shift });
+  }
+
+  function scrollHalfPageDown() {
+    for (let i = 0; i < 15; i++) {
+      moveDown();
+    }
+  }
+
+  function scrollHalfPageUp() {
+    for (let i = 0; i < 15; i++) {
+      moveUp();
+    }
   }
 
   //=============================================================================
@@ -1343,6 +1355,14 @@
     }
     if (e.ctrlKey && e.key === 'f') {
       sendKeyEvent("pageDown");
+      return;
+    }
+    if (e.ctrlKey && e.key === 'd') {
+      scrollHalfPageDown();
+      return;
+    }
+    if (e.ctrlKey && e.key === 'u') {
+      scrollHalfPageUp();
       return;
     }
     

--- a/src/keybinds.html
+++ b/src/keybinds.html
@@ -190,6 +190,14 @@
         <div class="key">Ctrl + f</div>
         <div class="description">Page down</div>
       </div>
+      <div class="shortcut">
+        <div class="key">Ctrl + d</div>
+        <div class="description">Move cursor and screen down 1/2 page</div>
+      </div>
+      <div class="shortcut">
+        <div class="key">Ctrl + u</div>
+        <div class="description">Move cursor and screen up 1/2 page</div>
+      </div>
       <!-- Added Arrow Key Commands -->
       <div class="shortcut">
         <div class="key">←</div>


### PR DESCRIPTION
## Summary
- add `<Ctrl-d>` and `<Ctrl-u>` to navigation docs
- document new shortcuts in keybinds page
- implement `scrollHalfPageDown` and `scrollHalfPageUp`
- handle the new key combos in normal mode

## Testing
- `npm test` *(fails: Could not read package.json)*